### PR TITLE
refactor: simplify build recipe

### DIFF
--- a/chiselled-base-ssl/Dockerfile.22.04
+++ b/chiselled-base-ssl/Dockerfile.22.04
@@ -1,36 +1,25 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=ubuntu UID=101 GROUP=ubuntu GID=101
 
-FROM golang:1.18 AS chisel
-ARG UBUNTU_RELEASE
-RUN git clone -b ubuntu-${UBUNTU_RELEASE}_2 https://github.com/cjdcordeiro/chisel-releases /opt/chisel-releases \
-    && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
 FROM ubuntu:$UBUNTU_RELEASE AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
 
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+# TODO: remove this branch once the libc-bin_nsswitch slice is merged
+RUN git clone -b ubuntu-${UBUNTU_RELEASE}_2 https://github.com/cjdcordeiro/chisel-releases /opt/chisel-releases
+
 RUN mkdir -p /rootfs/etc \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
 
-FROM scratch AS image-prep
-ARG UID GID
-USER $UID:$GID
-
 ### BOILERPLATE END ###
 
-FROM rootfs-prep AS sliced-deps
-COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
 RUN chisel cut --release /opt/chisel-releases --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -42,5 +31,6 @@ RUN chisel cut --release /opt/chisel-releases --root /rootfs \
     libssl3_libs \
     openssl_config
 
-FROM image-prep
-COPY --from=sliced-deps /rootfs /
+FROM scratch
+ARG USER UID GROUP GID
+COPY --from=builder /rootfs /

--- a/chiselled-base/Dockerfile.22.04
+++ b/chiselled-base/Dockerfile.22.04
@@ -1,36 +1,25 @@
 ARG UBUNTU_RELEASE=22.04
 ARG USER=ubuntu UID=101 GROUP=ubuntu GID=101
 
-FROM golang:1.18 AS chisel
-ARG UBUNTU_RELEASE
-RUN git clone -b ubuntu-${UBUNTU_RELEASE}_2 https://github.com/cjdcordeiro/chisel-releases /opt/chisel-releases \
-    && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
 FROM ubuntu:$UBUNTU_RELEASE AS builder
+ARG USER UID GROUP GID TARGETARCH UBUNTU_RELEASE
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates git \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
 
-FROM builder AS rootfs-prep
-ARG USER UID GROUP GID
+ADD "https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz" chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+# TODO: remove this branch once the libc-bin_nsswitch slice is merged
+RUN git clone -b ubuntu-${UBUNTU_RELEASE}_2 https://github.com/cjdcordeiro/chisel-releases /opt/chisel-releases
+
 RUN mkdir -p /rootfs/etc \
     && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
 
-FROM scratch AS image-prep
-ARG UID GID
-USER $UID:$GID
-
 ### BOILERPLATE END ###
 
-FROM rootfs-prep AS sliced-deps
-COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
 RUN chisel cut --release /opt/chisel-releases --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -38,7 +27,8 @@ RUN chisel cut --release /opt/chisel-releases --root /rootfs \
     ca-certificates_data \
     libc-bin_nsswitch \
     libgcc-s1_libs \
-    libc6_libs 
+    libc6_libs
 
-FROM image-prep
-COPY --from=sliced-deps /rootfs /
+FROM scratch
+ARG USER UID GROUP GID
+COPY --from=builder /rootfs /


### PR DESCRIPTION
Download v0.8.0 chisel binary from GitHub release instead of building it. Additionally, do not download chisel-releases initially, chisel will fetch it as needed.

Merge a few stages to simplify the Dockerfiles.
